### PR TITLE
Add support for treating Metafield/Metaobject definitions as a database schema

### DIFF
--- a/lib/shopify_toolkit/command_line.rb
+++ b/lib/shopify_toolkit/command_line.rb
@@ -53,6 +53,24 @@ class ShopifyToolkit::CommandLine < Thor
     Result.class_eval { binding.irb(show_code: false) }
   end
 
+  desc "migrate", "Run migrations"
+  def migrate
+    require "./config/environment"
+    ::Shop.sole.with_shopify_session { ShopifyToolkit::Migrator.new.up }
+  end
+
+  desc "down", "Run migrations down"
+  def down
+    require "./config/environment"
+    ::Shop.sole.with_shopify_session { ShopifyToolkit::Migrator.new.down }
+  end
+
+  desc "redo", "Run migrations down and up again"
+  def redo
+    require "./config/environment"
+    ::Shop.sole.with_shopify_session { ShopifyToolkit::Migrator.new.redo }
+  end
+
   desc "schema_load", 'Load schema from "config/shopify/schema.rb"'
   def schema_load
     require "./config/environment"

--- a/lib/shopify_toolkit/migration.rb
+++ b/lib/shopify_toolkit/migration.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "active_support/benchmark"
+
+class ShopifyToolkit::Migration
+  include ShopifyToolkit::AdminClient
+  include ShopifyToolkit::MetafieldStatements
+  include ShopifyToolkit::MetaobjectStatements
+  include ShopifyToolkit::Migration::Logging
+
+  class IrreversibleMigration < StandardError
+  end
+
+  def logger
+    @logger ||= ActiveSupport::Logger.new(STDOUT).tap do |logger|
+      logger.formatter = proc do |severity, datetime, progname, msg|
+        "#{severity}: #{msg}\n"
+      end
+    end
+  end
+
+  def self.[](api_version)
+    klass = Class.new(self)
+    klass.const_set(:API_VERSION, api_version)
+    klass
+  end
+
+  attr_reader :name, :version
+
+  def initialize(name, version)
+    @name    = name
+    @version = version
+  end
+
+  def announce(message)
+    super "#{version} #{name}: #{message}"
+  end
+
+  def migrate(direction)
+    case direction
+    when :up
+      announce("migrating")
+      time_elapsed = ActiveSupport::Benchmark.realtime { up }
+      announce("migrated (%.4fs)" % time_elapsed)
+
+    when :down
+      announce("reverting")
+      time_elapsed = ActiveSupport::Benchmark.realtime { down }
+      announce("reverted (%.4fs)" % time_elapsed)
+
+    else
+      raise ArgumentError, "Unknown migration direction: #{direction}"
+    end
+  end
+
+  def up
+    # Implement in subclass
+  end
+
+  def down
+    raise IrreversibleMigration
+  end
+end

--- a/lib/shopify_toolkit/migrator.rb
+++ b/lib/shopify_toolkit/migrator.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "active_support/benchmarkable"
+require "active_support/core_ext/module/delegation"
+
+class ShopifyToolkit::Migrator # :nodoc:
+  include ShopifyToolkit::AdminClient
+  include ShopifyToolkit::MetafieldStatements
+
+  singleton_class.attr_accessor :migrations_paths
+  self.migrations_paths = ["config/shopify/migrate"]
+
+  attr_reader :migrated_versions, :migrations, :migrations_paths
+
+  def initialize(migrations_paths: self.class.migrations_paths)
+    @migrations_paths  = migrations_paths
+    @migrated_versions = read_or_create_metafield["migrated_versions"]
+    @migrations        = load_migrations # [MigrationProxy<Migration1>, MigrationProxy<Migration2>, ...]
+  end
+
+  def current_version
+    migrated.max || 0
+  end
+
+  def up
+    pending_migrations = migrations.reject { migrated_versions.include?(_1.version) }
+
+    pending_migrations.each do |migration|
+      migration.migrate(:up)
+      migrated_versions << migration.version
+    end
+  ensure
+    update_metafield
+  end
+
+  def executed_migrations
+    migrations.select { migrated_versions.include?(_1.version) }
+  end
+
+  def down
+    # For now we'll just rollback the last one
+    executed_migrations.last(1).each do |migration|
+      migration.migrate(:down)
+      migrated_versions.delete(migration.version)
+    end
+  ensure
+    update_metafield
+  end
+
+  def query(query, **variables)
+    shopify_admin_client
+      .query(query:, variables:)
+      .tap { handle_shopify_admin_client_errors(_1) }
+      .body
+      .dig("data")
+  end
+
+  def update_metafield
+    namespace = :shopify_toolkit
+    key = :migrations
+
+    value = { "migrated_versions" => migrated_versions.to_a.sort }.to_json
+
+    owner_id = query(%(query GetShopGId { shop { id } })).dig("shop", "id")
+
+    query = <<~GRAPHQL
+      mutation metafieldsSet($metafields: [MetafieldsSetInput!]!) {
+        metafieldsSet(metafields: $metafields) {
+          userErrors {
+            field
+            message
+          }
+        }
+      }
+    GRAPHQL
+    query(query, metafields: [{ namespace:, key:, ownerId: owner_id, value: }])
+
+    nil
+  end
+
+  def read_or_create_metafield
+    namespace = :shopify_toolkit
+    key = :migrations
+
+    value = query(
+      "query ShopMetafield($namespace: String!, $key: String!) {shop {metafield(namespace: $namespace, key: $key) {value}}}",
+      namespace:, key:,
+    ).dig("shop", "metafield", "value")
+
+    if value.nil?
+      create_metafield :shop, key, :json, namespace:, name: "Migrations metadata"
+      return { "migrated_versions" => [] }
+    end
+
+    JSON.parse(value)
+  end
+
+  def redo
+    down
+    up
+  end
+
+  def migration_files
+    paths = Array(migrations_paths)
+    Dir[*paths.flat_map { |path| "#{path}/**/[0-9]*_*.rb" }]
+  end
+
+  def parse_migration_filename(filename)
+    File.basename(filename).scan(/\A([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.rb\z/).first
+  end
+
+  def load_migrations
+    migrations = migration_files.map do |file|
+      version, name, scope = parse_migration_filename(file)
+      raise "missing version #{file}" unless version
+      raise "missing name #{file}" unless name
+      version = version.to_i
+      name = name.camelize
+
+      MigrationProxy.new(name, version, file, scope)
+    end
+
+    migrations.sort_by(&:version)
+  end
+
+  # MigrationProxy is used to defer loading of the actual migration classes
+  # until they are needed
+  MigrationProxy = Struct.new(:name, :version, :filename, :scope) do
+    def initialize(name, version, filename, scope)
+      super
+      @migration = nil
+    end
+
+    def basename
+      File.basename(filename)
+    end
+
+    delegate :migrate, :up, :down, :announce, :say, :say_with_time, to: :migration
+
+    private
+      def migration
+        @migration ||= load_migration
+      end
+
+      def load_migration
+        Object.send(:remove_const, name) rescue nil
+
+        load(File.expand_path(filename))
+        name.constantize.new(name, version)
+      end
+  end
+end


### PR DESCRIPTION
This pull request introduces a migration framework for the Shopify Toolkit, enabling the management of migrations through a set of commands and supporting classes. The key changes include adding command-line tasks for migrations, implementing a `Migration` base class, and creating a `Migrator` class to handle migration execution and metadata management.

### Command-line enhancements:
* Added new commands (`migrate`, `down`, `redo`) to run migrations up, down, or redo them, utilizing the `ShopifyToolkit::Migrator` class. (`lib/shopify_toolkit/command_line.rb`, [lib/shopify_toolkit/command_line.rbR56-R73](diffhunk://#diff-3b33b0f9e0829c9c18c80183378623005ea5afa6e46f0f7587f5c9b2df338d54R56-R73))

### Migration framework:
* Introduced a `ShopifyToolkit::Migration` base class with methods for defining `up` and `down` migrations, logging, and handling migration directions. (`lib/shopify_toolkit/migration.rb`, [lib/shopify_toolkit/migration.rbR1-R63](diffhunk://#diff-0fa82c779f6d8ebfa570209b7d96b993b26f499ca4588da4a0e5f62b53520f21R1-R63))
* Added error handling for irreversible migrations via a custom `IrreversibleMigration` exception. (`lib/shopify_toolkit/migration.rb`, [lib/shopify_toolkit/migration.rbR1-R63](diffhunk://#diff-0fa82c779f6d8ebfa570209b7d96b993b26f499ca4588da4a0e5f62b53520f21R1-R63))

### Migration execution and metadata management:
* Created a `ShopifyToolkit::Migrator` class to load, execute, and manage migrations, including metafield-based storage of migrated versions for tracking state. (`lib/shopify_toolkit/migrator.rb`, [lib/shopify_toolkit/migrator.rbR1-R152](diffhunk://#diff-c35a27d5be4f79670632144e5719a00872f40d3c2c70b54a048751099e64b7f7R1-R152))
* Implemented `MigrationProxy` to defer loading of migration classes until needed, improving efficiency and modularity. (`lib/shopify_toolkit/migrator.rb`, [lib/shopify_toolkit/migrator.rbR1-R152](diffhunk://#diff-c35a27d5be4f79670632144e5719a00872f40d3c2c70b54a048751099e64b7f7R1-R152))