### PR TITLE
Add Metafield Migration Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,35 @@ bundle add shopify_toolkit
 
 ## Usage
 
+### Migrating Metafields definitions
+
+Within a Rails application created with ShopifyApp, generate a new migration file:
+
+```bash
+rails generate migration AddMetafieldDefinitions
+```
+
+Include the `ShopifyToolkit::MetafieldStatements` module in your migration file
+in order to use the metafield statements:
+
+```ruby
+class AddMetafieldDefinitions < ActiveRecord::Migration[7.0]
+  include ShopifyToolkit::MetafieldStatements
+
+  def up
+    Shop.first!.with_shopify_session do
+      create_metafield :products, :my_metafield, :single_line_text_field, name: "My Metafield"
+    end
+  end
+
+  def down
+    Shop.first!.with_shopify_session do
+      remove_metafield :products, :my_metafield
+    end
+  end
+end
+```
+
 ### Analyzing a Matrixify CSV Result files
 
 Matrixify is a popular Shopify app that allows you to import/export data from Shopify using CSV files. The CSV files that Matrixify generates are very verbose and can be difficult to work with. This tool allows you to analyze the CSV files and extract the data you need.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ bundle add shopify_toolkit
 
 ## Usage
 
-### Migrating Metafields definitions
+### Migrating Metafields definitions using ActiveRecord Migrations
 
 Within a Rails application created with ShopifyApp, generate a new migration file:
 
@@ -48,6 +48,25 @@ class AddMetafieldDefinitions < ActiveRecord::Migration[7.0]
       remove_metafield :products, :my_metafield
     end
   end
+end
+```
+Then run the migration:
+
+```bash
+rails db:migrate
+```
+
+### Creating a Metafield Schema Definition
+
+You can also create a metafield schema definition file to define your metafields in a more structured way. This is useful for keeping track of your metafields and their definitions.
+
+```rb
+# config/shopify/schema.rb
+
+ShopifyToolkit::MetafieldSchema.define do
+  # Define your metafield schema here
+  # For example:
+  create_metafield :products, :my_metafield, :single_line_text_field, name: "My Metafield"
 end
 ```
 

--- a/exe/shopify-toolkit
+++ b/exe/shopify-toolkit
@@ -5,7 +5,7 @@ require 'active_record'
 require 'thor'
 require 'tmpdir'
 
-class ShopifyCSV < Thor
+class ShopifyToolkit::CommandLine < Thor
   RESERVED_COLUMN_NAMES = %w[select type id]
 
   class Result < ActiveRecord::Base
@@ -56,4 +56,4 @@ class ShopifyCSV < Thor
   end
 end
 
-ShopifyCSV.start(ARGV)
+ShopifyToolkit::CommandLine.start(ARGV)

--- a/lib/shopify_toolkit.rb
+++ b/lib/shopify_toolkit.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 require_relative "shopify_toolkit/version"
+require "zeitwerk"
 
 module ShopifyToolkit
-  class Error < StandardError; end
-  # Your code goes here...
+
+  def self.loader
+    @loader ||= Zeitwerk::Loader.for_gem
+  end
+
+  loader.setup
+  # loader.eager_load # optionally
 end

--- a/lib/shopify_toolkit/admin_client.rb
+++ b/lib/shopify_toolkit/admin_client.rb
@@ -1,0 +1,39 @@
+module ShopifyToolkit::AdminClient
+  API_VERSION = "2024-10"
+
+  def api_version
+    API_VERSION
+  end
+
+  def shopify_admin_client
+    @shopify_admin_client ||=
+      ShopifyAPI::Clients::Graphql::Admin.new(session: ShopifyAPI::Context.active_session, api_version:)
+  end
+
+  def handle_shopify_admin_client_errors(response, *user_error_paths)
+    if response.code != 200
+      logger.error "Error querying Shopify Admin API: #{response.inspect}"
+      raise "Error querying Shopify Admin API: #{response.inspect}"
+    end
+
+    response
+      .body
+      .dig("errors")
+      .to_a
+      .each do |error|
+        logger.error "Error querying Shopify Admin API: #{error.inspect}"
+        raise "Error querying Shopify Admin API: #{error.inspect}"
+      end
+
+    user_error_paths.each do |path|
+      response
+        .body
+        .dig(*path.split("."))
+        .to_a
+        .each do |error|
+          logger.error "Error querying Shopify Admin API: #{error.inspect} (#{path})"
+          raise "Error querying Shopify Admin API: #{error.inspect} (#{path})"
+        end
+    end
+  end
+end

--- a/lib/shopify_toolkit/metafield_statements.rb
+++ b/lib/shopify_toolkit/metafield_statements.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "shopify_toolkit/migration/logging"
+require "shopify_toolkit/admin_client"
+
+module ShopifyToolkit::MetafieldStatements
+  extend ActiveSupport::Concern
+  include ShopifyToolkit::Migration::Logging
+  include ShopifyToolkit::AdminClient
+
+  def self.log_time(method_name)
+    current_method = instance_method(method_name)
+    define_method(method_name) do |*args, **kwargs, &block|
+      say_with_time("#{method_name}(#{args.map(&:inspect).join(', ')})") { current_method.bind(self).call(*args, **kwargs, &block) }
+    end
+  end
+
+  # create_metafield :products, :my_metafield, :single_line_text_field, name: "Prova"
+  # @param namespace: if nil the metafield will be app-specific (default: :custom)
+  log_time \
+  def create_metafield(owner_type, key, type, namespace: :custom, name:, **options)
+    ownerType = owner_type.to_s.singularize.upcase # Eg. "PRODUCT"
+
+    # https://shopify.dev/docs/api/admin-graphql/2024-10/mutations/metafieldDefinitionCreate
+    query =
+      "# GraphQL
+        mutation CreateMetafieldDefinition($definition: MetafieldDefinitionInput!) {
+          metafieldDefinitionCreate(definition: $definition) {
+            createdDefinition {
+              id
+              key
+            }
+            userErrors {
+              field
+              message
+              code
+            }
+          }
+        }
+      "
+    variables = { definition: { ownerType:, key:, type:, name:, namespace:, **options } }
+
+    shopify_admin_client
+      .query(query:, variables:)
+      .tap { handle_shopify_admin_client_errors(_1, "metafieldDefinitionCreate.userErrors") }
+  end
+
+  def get_metafield_gid(owner_type, key, namespace: :custom)
+    ownerType = owner_type.to_s.singularize.upcase # Eg. "PRODUCT"
+
+    result =
+      shopify_admin_client
+        .query(
+          query:
+            "# GraphQL
+              query FindMetafieldDefinition($ownerType: MetafieldOwnerType!, $key: String!) {
+                metafieldDefinitions(first: 1, ownerType: $ownerType, key: $key) {
+                  nodes { id }
+                }
+              }",
+          variables: {
+            ownerType:,
+            key:,
+            namespace:,
+          },
+        )
+        .tap { handle_shopify_admin_client_errors(_1) }
+        .body
+
+    result.dig("data", "metafieldDefinitions", "nodes", 0, "id") or
+      raise "Metafield not found for #{owner_type}##{namespace}:#{key}"
+  end
+
+  log_time \
+  def remove_metafield(owner_type, key, namespace: :custom, delete_associated_metafields: false, **options)
+    if namespace == nil && delete_associated_metafields == false
+      raise ArgumentError,
+            "For reserved namespaces, you must delete all associated metafields (delete_associated_metafields: true)"
+    end
+
+    shopify_admin_client
+      .query(
+        # Documentation: https://shopify.dev/docs/api/admin-graphql/2024-10/mutations/metafieldDefinitionDelete
+        query:
+          "# GraphQL
+            mutation DeleteMetafieldDefinition($id: ID!, $deleteAllAssociatedMetafields: Boolean!) {
+              metafieldDefinitionDelete(id: $id, deleteAllAssociatedMetafields: $deleteAllAssociatedMetafields) {
+                deletedDefinitionId
+                userErrors {
+                  field
+                  message
+                  code
+                }
+              }
+            }",
+        variables: {
+          id: get_metafield_gid(owner_type, key, namespace: namespace),
+          deleteAllAssociatedMetafields: delete_associated_metafields,
+        },
+      )
+      .tap { handle_shopify_admin_client_errors(_1, "metafieldDefinitionDelete.userErrors") }
+  end
+
+  def update_metafield(owner_type, key, namespace: :custom, **options)
+  log_time \
+    shopify_admin_client
+      .query(
+        # Documentation: https://shopify.dev/docs/api/admin-graphql/2024-10/mutations/metafieldDefinitionUpdate
+        query:
+          "# GraphQL
+            mutation UpdateMetafieldDefinition($definition: MetafieldDefinitionUpdateInput!) {
+              metafieldDefinitionUpdate(definition: $definition) {
+                updatedDefinition {
+                  id
+                  name
+                }
+                userErrors {
+                  field
+                  message
+                  code
+                }
+              }
+            }",
+        variables: {
+          definition: {
+            ownerType: owner_type.to_s.singularize.upcase,
+            key:,
+            namespace:,
+            **options,
+          },
+        },
+      )
+      .tap { handle_shopify_admin_client_errors(_1, "metafieldDefinitionUpdate.userErrors") }
+  end
+end

--- a/lib/shopify_toolkit/metafield_statements.rb
+++ b/lib/shopify_toolkit/metafield_statements.rb
@@ -132,4 +132,12 @@ module ShopifyToolkit::MetafieldStatements
       )
       .tap { handle_shopify_admin_client_errors(_1, "metafieldDefinitionUpdate.userErrors") }
   end
+
+  def self.define(&block)
+    context = Object.new
+    context.extend(self)
+
+    context.instance_eval(&block) if block_given?(&block)
+    context
+  end
 end

--- a/lib/shopify_toolkit/migration/logging.rb
+++ b/lib/shopify_toolkit/migration/logging.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ShopifyToolkit::Migration::Logging
+  def write(text = "")
+    puts(text)
+  end
+
+  def announce(message)
+    text = "#{version} #{name}: #{message}"
+    length = [0, 75 - text.length].max
+    write "== %s %s" % [text, "=" * length]
+  end
+
+  # Takes a message argument and outputs it as is.
+  # A second boolean argument can be passed to specify whether to indent or not.
+  def say(message, subitem = false)
+    write "#{subitem ? "   ->" : "--"} #{message}"
+  end
+
+  # Outputs text along with how long it took to run its block.
+  # If the block returns an integer it assumes it is the number of rows affected.
+  def say_with_time(message)
+    say(message)
+    result = nil
+    time_elapsed = ActiveSupport::Benchmark.realtime { result = yield }
+    say "%.4fs" % time_elapsed, :subitem
+    result
+  end
+end

--- a/shopify_toolkit.gemspec
+++ b/shopify_toolkit.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "thor", ">= 1.3"
+  spec.add_dependency "activesupport", ">= 7.0"
+  spec.add_dependency "shopify_api", ">= 14.8"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/shopify_toolkit.gemspec
+++ b/shopify_toolkit.gemspec
@@ -33,8 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "thor", ">= 1.3"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/shopify_toolkit.gemspec
+++ b/shopify_toolkit.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "thor", ">= 1.3"
+  spec.add_dependency "zeitwerk", ">= 2.7"
   spec.add_dependency "activesupport", ">= 7.0"
   spec.add_dependency "shopify_api", ">= 14.8"
 


### PR DESCRIPTION
Introduced `ShopifyToolkit::MetafieldStatements` module with methods for creating, updating, and removing metafields, including error handling for Shopify Admin API responses. (`lib/shopify_toolkit/metafield_statements.rb`)

### Other changes:
* Renamed the CLI from `shopify-csv` to `shopify-toolkit`
* Added missing dependency for `thor`
* Added `zeitwerk` to manage autoloading
