### PR TITLE
Add schema load/dump commands for metafields

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A toolkit for working with Custom Shopify Apps built on Rails.
 
+### Assumptions
+
+- You are using Rails 7.0 or later
+- The custom app is only installed on a single store
+- In order for the schema dump/load to work, you need to have the `shopify_app` gem installed and configured
+
 ## Features/Roadmap
 
 - [x] Shopify/Matrixify CSV tools

--- a/exe/shopify-toolkit
+++ b/exe/shopify-toolkit
@@ -54,6 +54,18 @@ class ShopifyToolkit::CommandLine < Thor
     IRB.conf[:IRB_NAME] = basename
     Result.class_eval { binding.irb(show_code: false) }
   end
+
+  desc "schema_load", 'Load schema from "config/shopify/schema.rb"'
+  def schema_load
+    require "./config/environment"
+    ::Shop.sole.with_shopify_session { ShopifyToolkit::Schema.load! }
+  end
+
+  desc "schema_dump", 'Dump schema to "config/shopify/schema.rb"'
+  def schema_dump
+    require "./config/environment"
+    ::Shop.sole.with_shopify_session { ShopifyToolkit::Schema.dump! }
+  end
 end
 
 ShopifyToolkit::CommandLine.start(ARGV)

--- a/lib/shopify_toolkit/migration/logging.rb
+++ b/lib/shopify_toolkit/migration/logging.rb
@@ -6,9 +6,8 @@ module ShopifyToolkit::Migration::Logging
   end
 
   def announce(message)
-    text = "#{version} #{name}: #{message}"
-    length = [0, 75 - text.length].max
-    write "== %s %s" % [text, "=" * length]
+    length = [0, 75 - message.length].max
+    write "== %s %s" % [message, "=" * length]
   end
 
   # Takes a message argument and outputs it as is.

--- a/lib/shopify_toolkit/schema.rb
+++ b/lib/shopify_toolkit/schema.rb
@@ -1,0 +1,116 @@
+module ShopifyToolkit::Schema
+  extend self
+  include ShopifyToolkit::MetafieldStatements
+  include ShopifyToolkit::Migration::Logging
+  SCHEMA_PATH = "config/shopify/schema.rb"
+
+  def load!
+    path = Rails.root.join(SCHEMA_PATH)
+
+    unless path.exist?
+      logger.warn "Schema file not found at #{path}."
+      return
+    end
+
+    announce "Loading metafield schema from #{path}"
+    say_with_time "Executing schema statements" do
+      load path
+    end
+  end
+
+  def dump!
+    schema_path = Rails.root.join(SCHEMA_PATH)
+
+    announce "Dumping metafield schema to #{schema_path}"
+    say_with_time "Generating schema" do
+      content = generate_schema_content
+      File.write(schema_path, content)
+    end
+  end
+
+  def define(&block)
+    instance_eval(&block)
+  end
+
+  def fetch_definitions
+    query = <<~GRAPHQL
+      query {
+        metafieldDefinitions(first: 250, ownerType: PRODUCT) {
+          nodes {
+            id
+            name
+            key
+            type {
+              name
+            }
+            namespace
+            description
+            validations {
+              name
+              value
+            }
+            capabilities {
+              smartCollectionCondition {
+                enabled
+              }
+              adminFilterable {
+                enabled
+              }
+            }
+            access {
+              admin
+              customerAccount
+              storefront
+            }
+            ownerType
+          }
+        }
+      }
+    GRAPHQL
+
+    result = shopify_admin_client.query(query:).tap { handle_shopify_admin_client_errors(_1) }.body
+
+    result.dig("data", "metafieldDefinitions", "nodes") || []
+  end
+
+  def generate_schema_content
+    definitions = fetch_definitions
+    content = ["ShopifyToolkit::Schema.define do"]
+
+    definitions.each do |defn|
+      owner_type = defn["ownerType"].downcase.pluralize.to_sym
+      key = defn["key"].to_sym
+      type = defn["type"]["name"].to_sym
+      name = defn["name"]
+      namespace = defn["namespace"]&.to_sym
+      description = defn["description"]
+      validations = defn["validations"]&.map { |v| v.transform_keys(&:to_sym) }
+      capabilities = defn["capabilities"]&.transform_keys(&:to_sym)&.transform_values { |v| v.transform_keys(&:to_sym) }
+
+      args = [owner_type, key, type]
+      kwargs = { name: name }
+      kwargs[:namespace] = namespace if namespace && namespace != :custom
+      kwargs[:description] = description if description
+      kwargs[:validations] = validations if validations.present?
+
+      # Only include capabilities if they have non-default values
+      if capabilities.present?
+        has_non_default_capabilities =
+          capabilities.any? do |cap, value|
+            case cap
+            when :smartCollectionCondition, :adminFilterable
+              value[:enabled] == true
+            else
+              true
+            end
+          end
+        kwargs[:capabilities] = capabilities if has_non_default_capabilities
+      end
+
+      content << "  create_metafield #{args.map(&:inspect).join(", ")}, #{kwargs.map { |k, v| "#{k}: #{v.inspect}" }.join(", ")}"
+    end
+
+    content << "end"
+    content.join("\n")
+  end
+end

--- a/shopify_toolkit.gemspec
+++ b/shopify_toolkit.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "railties", ">= 7"
+  spec.add_dependency "activerecord", ">= 7"
   spec.add_dependency "thor", ">= 1.3"
   spec.add_dependency "zeitwerk", ">= 2.7"
   spec.add_dependency "activesupport", ">= 7.0"


### PR DESCRIPTION
Introduce commands to manage Shopify metafield definitions via a schema file.

- Add `shopify-toolkit schema_dump`: Fetches existing metafield definitions for products from the Shopify Admin API and generates a `config/shopify/schema.rb` file containing `create_metafield` statements.
- Add `shopify-toolkit schema_load`: Loads and executes the `create_metafield` statements defined in `config/shopify/schema.rb`. This allows defining metafields in code and applying them to the store.
- Implement the core logic for fetching and generating the schema in `lib/shopify_toolkit/schema.rb`.
- Add `railties` and `activerecord` as dependencies in the gemspec.
- Update README to clarify assumptions (Rails >= 7, single store).