### PR TITLE
Add some metaobject statements (find/create/update)

### DIFF
--- a/lib/shopify_toolkit/metaobject_statements.rb
+++ b/lib/shopify_toolkit/metaobject_statements.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module ShopifyToolkit::MetaobjectStatements
+  extend ActiveSupport::Concern
+  include ShopifyToolkit::Migration::Logging
+  include ShopifyToolkit::AdminClient
+
+  def self.log_time(method_name)
+    current_method = instance_method(method_name)
+    define_method(method_name) do |*args, **kwargs, &block|
+      say_with_time("#{method_name}(#{args.map(&:inspect).join(', ')})") { current_method.bind(self).call(*args, **kwargs, &block) }
+    end
+  end
+
+  # create_metafield :products, :my_metafield, :single_line_text_field, name: "Prova"
+  # @param namespace: if nil the metafield will be app-specific (default: :custom)
+  log_time \
+  def create_metaobject_definition(type, **options)
+    # Skip creation if metafield already exists
+    existing_gid = get_metaobject_definition_gid(type)
+    if existing_gid
+      say "Metaobject #{type} already exists, skipping creation"
+      return existing_gid
+    end
+
+    # https://shopify.dev/docs/api/admin-graphql/2024-10/mutations/metafieldDefinitionCreate
+    query =
+      "# GraphQL
+      mutation CreateMetaobjectDefinition($definition: MetaobjectDefinitionCreateInput!) {
+        metaobjectDefinitionCreate(definition: $definition) {
+          metaobjectDefinition {
+            id
+            name
+            type
+            fieldDefinitions {
+              name
+              key
+            }
+          }
+          userErrors {
+            field
+            message
+            code
+          }
+        }
+      }
+      "
+    variables = { definition: { type:, **options } }
+
+    shopify_admin_client
+      .query(query:, variables:)
+      .tap { handle_shopify_admin_client_errors(_1, "data.metaobjectDefinitionCreate.userErrors") }
+  end
+
+  def get_metaobject_definition_gid(type)
+    result =
+      shopify_admin_client
+        .query(
+          query:
+            "# GraphQL
+              query GetMetaobjectDefinitionID($type: String!) {
+                metaobjectDefinitionByType(type: $type) {
+                  id
+                }
+              }",
+          variables: { type: type.to_s },
+        )
+        .tap { handle_shopify_admin_client_errors(_1) }
+        .body
+
+    result.dig("data", "metaobjectDefinitionByType", "id")
+  end
+
+  def update_metaobject_definition(type, **options)
+    existing_gid = get_metaobject_definition_gid(type)
+
+    raise "Metaobject #{type} does not exist" unless existing_gid
+
+    # https://shopify.dev/docs/api/admin-graphql/2024-10/mutations/metaobjectDefinitionUpdate
+    query =
+      "# GraphQL
+      mutation UpdateMetaobjectDefinition($id: ID!, $definition: MetaobjectDefinitionUpdateInput!) {
+        metaobjectDefinitionUpdate(id: $id, definition: $definition) {
+          metaobjectDefinition {
+            id
+            name
+            type
+            fieldDefinitions {
+              name
+              key
+            }
+          }
+          userErrors {
+            field
+            message
+            code
+          }
+        }
+      }
+    "
+    variables = { id: existing_gid, definition: { **options } }
+
+    shopify_admin_client
+      .query(query:, variables:)
+      .tap { handle_shopify_admin_client_errors(_1, "data.metaobjectDefinitionUpdate.userErrors") }
+  end
+
+  def self.define(&block)
+    context = Object.new
+    context.extend(self)
+
+    context.instance_eval(&block) if block_given?(&block)
+    context
+  end
+end


### PR DESCRIPTION
This pull request introduces a new module, `ShopifyToolkit::MetaobjectStatements`, which provides methods for managing Shopify metaobject definitions through GraphQL API interactions. The key changes include the addition of methods for creating, retrieving, and updating metaobject definitions, as well as utility methods for logging and context-based execution.

### New functionality for managing Shopify metaobject definitions:

* **Module introduction**: Added the `ShopifyToolkit::MetaobjectStatements` module, which includes methods for interacting with Shopify's metaobject GraphQL API. This module extends `ActiveSupport::Concern` and includes logging and admin client utilities. (`[lib/shopify_toolkit/metaobject_statements.rbR1-R117](diffhunk://#diff-8e5095a5b6fd4c1204e826824b2ca35c0f7dafe11c32c12905327359067b0750R1-R117)`)
* **Method `create_metaobject_definition`**: Implements functionality to create a new metaobject definition, with built-in checks to skip creation if the definition already exists. (`[lib/shopify_toolkit/metaobject_statements.rbR1-R117](diffhunk://#diff-8e5095a5b6fd4c1204e826824b2ca35c0f7dafe11c32c12905327359067b0750R1-R117)`)
* **Method `get_metaobject_definition_gid`**: Retrieves the global ID of an existing metaobject definition by its type. (`[lib/shopify_toolkit/metaobject_statements.rbR1-R117](diffhunk://#diff-8e5095a5b6fd4c1204e826824b2ca35c0f7dafe11c32c12905327359067b0750R1-R117)`)
* **Method `update_metaobject_definition`**: Updates an existing metaobject definition, raising an error if the metaobject does not exist. (`[lib/shopify_toolkit/metaobject_statements.rbR1-R117](diffhunk://#diff-8e5095a5b6fd4c1204e826824b2ca35c0f7dafe11c32c12905327359067b0750R1-R117)`)
* **Utility methods**: 
  - `log_time`: A utility to log the execution time of methods.
  - `self.define`: Allows the module to be used in a context-based manner for executing blocks of