### PR TITLE
Add delete functionality for Metaobject Definitions

### DIFF
--- a/lib/shopify_toolkit/metaobject_statements.rb
+++ b/lib/shopify_toolkit/metaobject_statements.rb
@@ -107,6 +107,36 @@ module ShopifyToolkit::MetaobjectStatements
       .tap { handle_shopify_admin_client_errors(_1, "data.metaobjectDefinitionUpdate.userErrors") }
   end
 
+  log_time \
+  def delete_metaobject_definition(type)
+    existing_gid = get_metaobject_definition_gid(type)
+
+    unless existing_gid
+      say "Metaobject #{type} does not exist, skipping deletion"
+      return
+    end
+
+    # https://shopify.dev/docs/api/admin-graphql/2024-10/mutations/metaobjectDefinitionDelete
+    query =
+      "# GraphQL
+      mutation DeleteMetaobjectDefinition($id: ID!) {
+        metaobjectDefinitionDelete(id: $id) {
+          deletedId
+          userErrors {
+            field
+            message
+            code
+          }
+        }
+      }
+      "
+    variables = { id: existing_gid }
+
+    shopify_admin_client
+      .query(query:, variables:)
+      .tap { handle_shopify_admin_client_errors(_1, "data.metaobjectDefinitionDelete.userErrors") }
+  end
+
   def self.define(&block)
     context = Object.new
     context.extend(self)


### PR DESCRIPTION
This pull request extends the `ShopifyToolkit::MetaobjectStatements` module by adding the ability to delete metaobject definitions through the Shopify GraphQL API.

### New functionality for deleting Shopify metaobject definitions:

* **Method `delete_metaobject_definition`**: Implements functionality to delete an existing metaobject definition by its type. The method includes built-in checks to skip deletion if the metaobject definition doesn't exist, providing user-friendly feedback. ([lib/shopify_toolkit/metaobject_statements.rb](diffhunk://#diff-8e5095a5b6fd4c1204e826824b2ca35c0f7dafe11c32c12905327359067b0750R110-R140))

### Key features:
- Uses the `metaobjectDefinitionDelete` GraphQL mutation from Shopify's Admin API
- Includes proper error handling through the existing `handle_shopify_admin_client_errors` method
- Gracefully handles cases where the metaobject definition doesn't exist
- Follows the existing code patterns and conventions in the module
- Includes the `log_time` decorator for performance monitoring

### Implementation details:
- Leverages the existing `get_metaobject_definition_gid` method to check for metaobject existence
- Uses the same GraphQL query structure and error handling patterns as other methods in the module
- Provides clear user feedback when attempting to delete non-existent metaobject definitions