### PR TITLE
Filter Shopify-proprietary metafields from schema dumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4"]
+        ruby-version: ["3.2", "3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /tmp/
 Gemfile.lock
 /.rspec_status
+/.tool-versions

--- a/lib/shopify_toolkit/command_line.rb
+++ b/lib/shopify_toolkit/command_line.rb
@@ -59,31 +59,31 @@ class ShopifyToolkit::CommandLine < Thor
   desc "migrate", "Run migrations"
   def migrate
     require "./config/environment"
-    ::Shop.sole.with_shopify_session { ShopifyToolkit::Migrator.new.up }
+    shop.with_shopify_session { ShopifyToolkit::Migrator.new.up }
   end
 
   desc "rollback", "Rollback last migration"
   def rollback
     require "./config/environment"
-    ::Shop.sole.with_shopify_session { ShopifyToolkit::Migrator.new.down }
+    shop.with_shopify_session { ShopifyToolkit::Migrator.new.down }
   end
 
-  desc "redo", "Run migrations down and up again"
+  desc "redo", "Run the last migration down and up again"
   def redo
     require "./config/environment"
-    ::Shop.sole.with_shopify_session { ShopifyToolkit::Migrator.new.redo }
+    shop.with_shopify_session { ShopifyToolkit::Migrator.new.redo }
   end
 
   desc "schema_load", 'Load schema from "config/shopify/schema.rb"'
   def schema_load
     require "./config/environment"
-    ::Shop.sole.with_shopify_session { ShopifyToolkit::Schema.load! }
+    shop.with_shopify_session { ShopifyToolkit::Schema.load! }
   end
 
   desc "schema_dump", 'Dump schema to "config/shopify/schema.rb"'
   def schema_dump
     require "./config/environment"
-    ::Shop.sole.with_shopify_session { ShopifyToolkit::Schema.dump! }
+    shop.with_shopify_session { ShopifyToolkit::Schema.dump! }
   end
 
   desc "generate_migration NAME", "Generate a migration with the given NAME"
@@ -113,5 +113,11 @@ class ShopifyToolkit::CommandLine < Thor
 
   def self.exit_on_failure?
     true
+  end
+
+  private
+
+  def shop
+    @shop ||= ENV["SHOPIFY_DOMAIN"] ? ::Shop.find_by(shopify_domain: ENV["SHOPIFY_DOMAIN"]) : ::Shop.sole
   end
 end

--- a/lib/shopify_toolkit/command_line.rb
+++ b/lib/shopify_toolkit/command_line.rb
@@ -118,6 +118,6 @@ class ShopifyToolkit::CommandLine < Thor
   private
 
   def shop
-    @shop ||= ENV["SHOPIFY_DOMAIN"] ? ::Shop.find_by(shopify_domain: ENV["SHOPIFY_DOMAIN"]) : ::Shop.sole
+    @shop ||= ENV["SHOPIFY_DOMAIN"].presence ? ::Shop.find_by!(shopify_domain: ENV["SHOPIFY_DOMAIN"]) : ::Shop.sole
   end
 end

--- a/lib/shopify_toolkit/schema.rb
+++ b/lib/shopify_toolkit/schema.rb
@@ -237,6 +237,18 @@ module ShopifyToolkit::Schema
     result.dig("data", "metaobjectDefinitions", "nodes") || []
   end
 
+  # Check if a metafield definition is Shopify-proprietary
+  # Shopify-proprietary items should not be dumped as they are managed by Shopify
+  def shopify_proprietary?(definition)
+    namespace = definition["namespace"]
+    return false if namespace.nil?
+
+    # Shopify-proprietary namespaces:
+    # - "shopify" namespace
+    # - Namespaces starting with "shopify--"
+    namespace == "shopify" || namespace.start_with?("shopify--")
+  end
+
   def generate_schema_content
     metaobject_definitions = fetch_metaobject_definitions
     metafield_definitions =
@@ -306,7 +318,9 @@ module ShopifyToolkit::Schema
     end
 
     # Add metafield definitions
+    # Sort for consistent output and filter out Shopify-proprietary items
     metafield_definitions
+      .reject { |definition| shopify_proprietary?(definition) }
       .sort_by { [_1["ownerType"], _1["namespace"], _1["key"]] }
       .each do
         owner_type = _1["ownerType"].downcase.pluralize.to_sym

--- a/spec/shopify_toolkit/schema_spec.rb
+++ b/spec/shopify_toolkit/schema_spec.rb
@@ -269,6 +269,61 @@ RSpec.describe ShopifyToolkit::Schema do
         )
       expect(root.join("config/shopify/schema.rb").read).to eq(expected_schema)
     end
+
+    context "with Shopify-proprietary metafields" do
+      let(:shopify_metafield) do
+        {
+          "id" => "gid://shopify/MetafieldDefinition/3",
+          "name" => "Dog age group",
+          "key" => "dog-age-group",
+          "type" => { "name" => "list.metaobject_reference" },
+          "namespace" => "shopify",
+          "description" => "Helps sort dog supplies",
+          "validations" => [],
+          "capabilities" => {},
+          "access" => { "admin" => true, "customerAccount" => false, "storefront" => false },
+          "ownerType" => "PRODUCT"
+        }
+      end
+
+      let(:shopify_discovery_metafield) do
+        {
+          "id" => "gid://shopify/MetafieldDefinition/4",
+          "name" => "Related products",
+          "key" => "related_products",
+          "type" => { "name" => "list.product_reference" },
+          "namespace" => "shopify--discovery--product_recommendation",
+          "description" => "List of related products",
+          "validations" => [],
+          "capabilities" => {},
+          "access" => { "admin" => true, "customerAccount" => false, "storefront" => true },
+          "ownerType" => "PRODUCT"
+        }
+      end
+
+      let(:definitions_by_owner) do
+        {
+          products: [product_definition, shopify_metafield, shopify_discovery_metafield],
+          articles: [article_definition]
+        }
+      end
+
+      it "excludes Shopify-proprietary metafields from the dump" do
+        schema.dump!
+
+        dumped_schema = root.join("config/shopify/schema.rb").read
+
+        # Should include custom metafields
+        expect(dumped_schema).to include("create_metafield :products, :my_metafield")
+        expect(dumped_schema).to include("create_metafield :articles, :my_metafield_2")
+
+        # Should NOT include Shopify-proprietary metafields
+        expect(dumped_schema).not_to include("dog-age-group")
+        expect(dumped_schema).not_to include("related_products")
+        expect(dumped_schema).not_to include("namespace: :shopify")
+        expect(dumped_schema).not_to include("shopify--discovery")
+      end
+    end
   end
 
   describe "#convert_validations_gids_to_types" do


### PR DESCRIPTION
Fixes the issue where Shopify-managed metafields were being included in schema dumps.

## Changes

- Added filtering logic to exclude metafields with `shopify` or `shopify--*` namespaces from schema dumps
- These are Shopify-managed metafields that should not be recreated from migrations
- Added tests to verify the filtering works correctly
- Also allow selecting shop via `SHOPIFY_DOMAIN` env var in CLI commands

## Examples of filtered metafields

- \`namespace: :shopify\` (e.g., dog-age-group, pet-food-flavor)
- \`namespace: :"shopify--discovery--product_recommendation"\` (e.g., related_products, complementary_products)

Co-Authored-By: GitHub Copilot <noreply@github.com>